### PR TITLE
Update rk3328 Dockerfile

### DIFF
--- a/rk3328/Dockerfile
+++ b/rk3328/Dockerfile
@@ -18,12 +18,17 @@ RUN mkdir -p /build/artifacts
 FROM deps AS download
 ARG ARM_FIRMWARE_TAG=lts-v2.8.6
 ARG ARM_FIRMWARE_SHASUM=489f36323dbeb426d3c129a49ced9d76330027fbc23fd8f533489561e1fc84ef
+ARG UBOOT_TAG=2023.10
+ARG UBOOT_SHASUM=b22664ee56640bba87068a7cdcd7cb50f956973a348e844788d2fb882fe0dc55
 RUN curl -L -O https://github.com/ARM-software/arm-trusted-firmware/archive/refs/tags/${ARM_FIRMWARE_TAG}.tar.gz \
  && echo "${ARM_FIRMWARE_SHASUM}  ${ARM_FIRMWARE_TAG}.tar.gz" | shasum -c \
  && tar xf ${ARM_FIRMWARE_TAG}.tar.gz \
  && ln -s arm-trusted-firmware-${ARM_FIRMWARE_TAG} arm-trusted-firmware \
- && git clone -b "u-boot/v2022.10/roc-rk3328-cc" \
-      https://github.com/libre-computer-project/libretech-u-boot.git
+ && curl -L -O https://github.com/u-boot/u-boot/archive/refs/tags/v${UBOOT_TAG}.tar.gz \
+ && echo "${UBOOT_SHASUM}  v${UBOOT_TAG}.tar.gz" | shasum -c \
+ && tar xf v${UBOOT_TAG}.tar.gz \
+ && ln -s u-boot-${UBOOT_TAG} u-boot \
+ && rm ${ARM_FIRMWARE_TAG}.tar.gz v${UBOOT_TAG}.tar.gz
 
 
 FROM download AS build
@@ -31,7 +36,7 @@ RUN cd arm-trusted-firmware \
  && make CROSS_COMPILE=aarch64-linux-gnu- PLAT=rk3328 \
  && cp build/rk3328/release/bl31/bl31.elf /build/artifacts/ \
  && cd ..
-RUN cd libretech-u-boot \
+RUN cd u-boot \
  && export BL31=/build/artifacts/bl31.elf \
  && make roc-cc-rk3328_defconfig \
  && make CROSS_COMPILE=aarch64-linux-gnu- \

--- a/rk3328/Dockerfile
+++ b/rk3328/Dockerfile
@@ -16,8 +16,8 @@ RUN apt update \
 RUN mkdir -p /build/artifacts
 
 FROM deps AS download
-ARG ARM_FIRMWARE_TAG=lts-v2.8.6
-ARG ARM_FIRMWARE_SHASUM=489f36323dbeb426d3c129a49ced9d76330027fbc23fd8f533489561e1fc84ef
+ARG ARM_FIRMWARE_TAG=lts-v2.8.9
+ARG ARM_FIRMWARE_SHASUM=9b1a9ce650e86017d274ed9389b3ff634e4c9c88f936ffffaf86c7d0cb22290e
 ARG UBOOT_TAG=2023.10
 ARG UBOOT_SHASUM=b22664ee56640bba87068a7cdcd7cb50f956973a348e844788d2fb882fe0dc55
 RUN curl -L -O https://github.com/ARM-software/arm-trusted-firmware/archive/refs/tags/${ARM_FIRMWARE_TAG}.tar.gz \

--- a/rk3328/Dockerfile
+++ b/rk3328/Dockerfile
@@ -44,11 +44,13 @@ RUN cd u-boot \
 
 FROM deps as assemble
 ARG SECTORS_TO_ADD=22528
-ARG IMG_FILE=20230430-jammy-preinstalled-server-arm64.img
+ARG IMG_FILE=20231014.2-jammy-preinstalled-server-arm64.img
 ARG IMG_URL=https://archive.very.engineer
-ARG OUT_IMG=rk3328-jammy-20230430.img
+ARG IMG_SHASUM=8e19655b5a0f84d2a5f9c9c57404723355f4e215764a93b67d0d68249c44c442
+ARG OUT_IMG=rk3328-jammy-20231014.2.img
 COPY --from=build /build/artifacts/* /build/artifacts/
 RUN curl -L -O ${IMG_URL}/${IMG_FILE}.xz \
+ && echo "${IMG_SHASUM}  ${IMG_FILE}.xz" | shasum -c \
  && unxz ${IMG_FILE}.xz \
  && mv ${IMG_FILE} ${OUT_IMG}
 RUN export IMAGE_SIZE=$(sfdisk --json ${OUT_IMG} | jq ".partitiontable.lastlba + 1 + 64") \


### PR DESCRIPTION
- The u-boot project has fixed the bugs that were preventing using their release tags. This PR uses u-boot v23.10 and pins it for security, removing the need to use the libretech fork and with that the obstacle of not having a pinnable source for u-boot. 
- Upgrades the ARM firmware from 2.8.6 to 2.8.9
- Updates the Ubuntu Jammy arm64 server image from 230430 to 231014.2
- Pins the OS image by checking the SHA256 checksum